### PR TITLE
Add arithmetic calculator

### DIFF
--- a/calculator.py
+++ b/calculator.py
@@ -1,0 +1,42 @@
+import ast
+import operator as op
+from typing import Union
+
+
+def _eval(node: ast.AST) -> Union[int, float]:
+    if isinstance(node, ast.Num):
+        return node.n
+    elif isinstance(node, ast.BinOp):
+        left = _eval(node.left)
+        right = _eval(node.right)
+        ops = {
+            ast.Add: op.add,
+            ast.Sub: op.sub,
+            ast.Mult: op.mul,
+            ast.Div: op.truediv,
+            ast.Pow: op.pow,
+            ast.Mod: op.mod,
+        }
+        if type(node.op) not in ops:
+            raise ValueError(f"Unsupported operator: {type(node.op).__name__}")
+        return ops[type(node.op)](left, right)
+    elif isinstance(node, ast.UnaryOp) and isinstance(node.op, (ast.UAdd, ast.USub)):
+        operand = _eval(node.operand)
+        return +operand if isinstance(node.op, ast.UAdd) else -operand
+    else:
+        raise ValueError(f"Unsupported expression: {ast.dump(node)}")
+
+
+def calculate(expression: str) -> Union[int, float]:
+    """Safely evaluate a simple arithmetic expression."""
+    tree = ast.parse(expression, mode="eval")
+    return _eval(tree.body)
+
+
+if __name__ == "__main__":
+    expr = input("Enter expression: ")
+    try:
+        result = calculate(expr)
+        print(result)
+    except Exception as e:
+        print(f"Error: {e}")

--- a/test_calculator.py
+++ b/test_calculator.py
@@ -1,0 +1,22 @@
+import calculator
+
+
+def test_addition():
+    assert calculator.calculate('2 + 3') == 5
+
+
+def test_subtraction():
+    assert calculator.calculate('10 - 4') == 6
+
+
+def test_multiplication():
+    assert calculator.calculate('6 * 7') == 42
+
+
+def test_division():
+    assert calculator.calculate('8 / 2') == 4
+
+
+def test_precedence():
+    assert calculator.calculate('2 + 3 * 4') == 14
+


### PR DESCRIPTION
## Summary
- add a simple arithmetic calculator with a safe evaluator
- test addition, subtraction, multiplication, division, and operator precedence

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685451af57808327a8ed6adf0f6d1df3